### PR TITLE
[ENH] lookup utility `all_estimators`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,9 @@
 # Welcome to BaseObject
 
 > A base class for scikit-learn-like parametric objects
+
+Temporary location of refactoring the `BaseObject` class and related functionality from `sktime` into a general package for unified parametric object interfaces.
+
+Maintainers:
+@rnkuhns (project lead)
+@fkiraly

--- a/baseobject/_lookup.py
+++ b/baseobject/_lookup.py
@@ -10,6 +10,8 @@ all_estimators(estimator_types, filter_tags)
 """
 
 __author__ = ["fkiraly", "mloning", "katiebuc", "rnkuhns"]
+# based on the sktime estimator retrieval utility of the same name
+# which, in turn, is based on the sklearn estimator retrieval utility of the same name
 
 
 import pkgutil

--- a/baseobject/_lookup.py
+++ b/baseobject/_lookup.py
@@ -12,7 +12,6 @@ all_objects(object_types, filter_tags)
 """
 # Based on the sktime all_estimator retrieval utility, which is based on the
 # sklearn estimator retrieval utility of the same name
-
 import importlib
 import inspect
 import io
@@ -20,8 +19,6 @@ import pkgutil
 import sys
 from collections.abc import Iterable
 from copy import deepcopy
-from importlib import import_module
-from inspect import getmembers, isclass
 from operator import itemgetter
 from pathlib import Path
 from types import FunctionType, ModuleType
@@ -30,7 +27,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type, Union
 from baseobject import BaseObject
 
 # Conditionally import TypedDict based on Python version
-if sys.version_info >= (3, 9):
+if sys.version_info >= (3, 8):
     from typing import TypedDict
 else:
     from typing_extensions import TypedDict
@@ -533,8 +530,6 @@ def all_objects(
     ----------
     Modified version from scikit-learn's `all_estimators()`.
     """
-    import io
-    import sys
     import warnings
 
     if ignore_modules is None:
@@ -545,12 +540,12 @@ def all_objects(
     all_estimators = []
     root = str(Path(__file__).parent.parent)  # sktime package root directory
 
-    def _is_abstract(klass):
-        if not (hasattr(klass, "__abstractmethods__")):
-            return False
-        if not len(klass.__abstractmethods__):
-            return False
-        return True
+    # def _is_abstract(klass):
+    #     if not (hasattr(klass, "__abstractmethods__")):
+    #         return False
+    #     if not len(klass.__abstractmethods__):
+    #         return False
+    #     return True
 
     def _is_private_module(module):
         return "._" in module
@@ -586,11 +581,11 @@ def all_objects(
                 if suppress_import_stdout:
                     # setup text trap, import, then restore
                     sys.stdout = io.StringIO()
-                    module = import_module(module_name)
+                    module = importlib.import_module(module_name)
                     sys.stdout = sys.__stdout__
                 else:
-                    module = import_module(module_name)
-                classes = getmembers(module, isclass)
+                    module = importlib.import_module(module_name)
+                classes = inspect.getmembers(module, inspect.isclass)
 
                 # Filter classes
                 estimators = [
@@ -610,7 +605,9 @@ def all_objects(
 
     # Filter based on given estimator types
     def _is_in_estimator_types(estimator, estimator_types):
-        return any(isclass(x) and isinstance(estimator, x) for x in estimator_types)
+        return any(
+            inspect.isclass(x) and isinstance(estimator, x) for x in estimator_types
+        )
 
     if estimator_types:
         estimator_types = _check_estimator_types(estimator_types, class_lookup)
@@ -726,10 +723,10 @@ def _check_list_of_class_or_error(arg_to_check, arg_name):
     TypeError if arg_to_check is not a class or list of class
     """
     # check that return_tags has the right type:
-    if isclass(arg_to_check, str):
+    if inspect.isclass(arg_to_check, str):
         arg_to_check = [arg_to_check]
     if not isinstance(arg_to_check, list) or not all(
-        isclass(value) for value in arg_to_check
+        inspect.isclass(value) for value in arg_to_check
     ):
         raise TypeError(
             f"Error in all_estimators!  Argument {arg_name} must be either\

--- a/baseobject/_lookup.py
+++ b/baseobject/_lookup.py
@@ -20,8 +20,6 @@ from inspect import isclass
 from operator import itemgetter
 from pathlib import Path
 
-import pandas as pd
-
 from baseobject import BaseObject
 
 from sktime.base import BaseEstimator
@@ -40,6 +38,13 @@ VALID_ESTIMATOR_TYPES = (
     *VALID_ESTIMATOR_BASE_TYPES,
     *VALID_TRANSFORMER_TYPES,
 )
+
+
+def _make_dataframe(all_estimators, columns):
+    """Create pandas.DataFrame for all_estimators, fct isolates pandas soft dep."""
+    import pandas as pd
+
+    return pd.DataFrame(all_estimators, columns=columns)
 
 
 def all_estimators(
@@ -81,10 +86,11 @@ def all_estimators(
     exclude_estimators: str, list of str, optional (default=None)
         Names of estimators to exclude.
     as_dataframe: bool, optional (default=False)
-        if True, all_estimators will return a pandas.DataFrame with named
-            columns for all of the attributes being returned.
         if False, all_estimators will return a list (either a list of
             estimators or a list of tuples, see Returns)
+        if True, all_estimators will return a pandas.DataFrame with named
+            columns for all of the attributes being returned.
+            this requires soft dependency pandas to be installed.
     return_tags: str or list of str, optional (default=None)
         Names of tags to fetch and return each estimator's value of.
         For a list of valid tag strings, use the registry.all_tags utility.
@@ -265,7 +271,7 @@ def all_estimators(
 
     # convert to pandas.DataFrame if as_dataframe=True
     if as_dataframe:
-        all_estimators = pd.DataFrame(all_estimators, columns=columns)
+        all_estimators = _make_dataframe(all_estimators, columns=columns)
 
     return all_estimators
 
@@ -451,7 +457,7 @@ def all_tags(
     # convert to pd.DataFrame if as_dataframe=True
     if as_dataframe:
         columns = ["name", "scitype", "type", "description"]
-        all_tags = pd.DataFrame(all_tags, columns=columns)
+        all_tags = _make_dataframe(all_tags, columns=columns)
 
     return all_tags
 

--- a/baseobject/_lookup.py
+++ b/baseobject/_lookup.py
@@ -1,0 +1,488 @@
+# -*- coding: utf-8 -*-
+# copyright: sktime developers, BSD-3-Clause License (see LICENSE file)
+"""
+Registry lookup methods.
+
+This module exports the following methods for registry lookup:
+
+all_estimators(estimator_types, filter_tags)
+    lookup and filtering of estimators
+
+all_tags(estimator_types)
+    lookup and filtering of estimator tags
+"""
+
+import inspect
+import pkgutil
+from copy import deepcopy
+from importlib import import_module
+from inspect import isclass
+from operator import itemgetter
+from pathlib import Path
+
+import pandas as pd
+
+from baseobject import BaseObject
+
+from sktime.base import BaseEstimator
+from sktime.registry._base_classes import (
+    BASE_CLASS_LIST,
+    BASE_CLASS_LOOKUP,
+    TRANSFORMER_MIXIN_LIST,
+)
+from sktime.registry._tags import ESTIMATOR_TAG_REGISTER
+
+VALID_TRANSFORMER_TYPES = tuple(TRANSFORMER_MIXIN_LIST)
+VALID_ESTIMATOR_BASE_TYPES = tuple(BASE_CLASS_LIST)
+
+VALID_ESTIMATOR_TYPES = (
+    BaseEstimator,
+    *VALID_ESTIMATOR_BASE_TYPES,
+    *VALID_TRANSFORMER_TYPES,
+)
+
+
+def all_estimators(
+    estimator_types=None,
+    filter_tags=None,
+    exclude_estimators=None,
+    return_names=True,
+    as_dataframe=False,
+    return_tags=None,
+    suppress_import_stdout=True,
+    ignore_modules=None,
+    package_name="baseobject",
+):
+    """Get a list of all estimators in the package with name package_name.
+
+    This function crawls the module and gets all classes that are BaseObject-s.
+
+    Not included are: the base classes themselves, classes defined in test modules.
+
+    Parameters
+    ----------
+    estimator_types: class, list of class, optional (default=None)
+        Which kind of objects should be returned.
+        if None, no filter is applied and all estimators are returned.
+        if class or list of class, estimators are filtered to inherit from one of these
+    return_names: bool, optional (default=True)
+        if True, estimator class name is included in the all_estimators()
+            return in the order: name, estimator class, optional tags, either as
+            a tuple or as pandas.DataFrame columns
+        if False, estimator class name is removed from the all_estimators()
+            return.
+    filter_tags: dict of (str or list of str), optional (default=None)
+        For a list of valid tag strings, use the registry.all_tags utility.
+        subsets the returned estimators as follows:
+            each key/value pair is statement in "and"/conjunction
+                key is tag name to sub-set on
+                value str or list of string are tag values
+                condition is "key must be equal to value, or in set(value)"
+    exclude_estimators: str, list of str, optional (default=None)
+        Names of estimators to exclude.
+    as_dataframe: bool, optional (default=False)
+        if True, all_estimators will return a pandas.DataFrame with named
+            columns for all of the attributes being returned.
+        if False, all_estimators will return a list (either a list of
+            estimators or a list of tuples, see Returns)
+    return_tags: str or list of str, optional (default=None)
+        Names of tags to fetch and return each estimator's value of.
+        For a list of valid tag strings, use the registry.all_tags utility.
+        if str or list of str,
+            the tag values named in return_tags will be fetched for each
+            estimator and will be appended as either columns or tuple entries.
+    suppress_import_stdout : bool, optional. Default=True
+        whether to suppress stdout printout upon import.
+    ignore_modules : str or lits of str, optional. Default=empty list
+        list of module names to ignore in search
+    package_name : str, optional. Default="baseobject".
+        should be set to default to package name if used for search
+
+    Returns
+    -------
+    all_estimators will return one of the following:
+        1. list of estimators, if return_names=False, and return_tags is None
+        2. list of tuples (optional estimator name, class, ~optional estimator
+                tags), if return_names=True or return_tags is not None.
+        3. pandas.DataFrame if as_dataframe = True
+        if list of estimators:
+            entries are estimators matching the query,
+            in alphabetical order of estimator name
+        if list of tuples:
+            list of (optional estimator name, estimator, optional estimator
+            tags) matching the query, in alphabetical order of estimator name,
+            where
+            ``name`` is the estimator name as string, and is an
+                optional return
+            ``estimator`` is the actual estimator
+            ``tags`` are the estimator's values for each tag in return_tags
+                and is an optional return.
+        if dataframe:
+            all_estimators will return a pandas.DataFrame.
+            column names represent the attributes contained in each column.
+            "estimators" will be the name of the column of estimators, "names"
+            will be the name of the column of estimator class names and the string(s)
+            passed in return_tags will serve as column names for all columns of
+            tags that were optionally requested.
+
+    References
+    ----------
+    Modified version from scikit-learn's `all_estimators()`.
+    """
+    import io
+    import sys
+    import warnings
+
+    if ignore_modules is None:
+        MODULES_TO_IGNORE = []
+    else:
+        MODULES_TO_IGNORE = ignore_modules
+
+    all_estimators = []
+    ROOT = str(Path(__file__).parent.parent)  # sktime package root directory
+
+    def _is_abstract(klass):
+        if not (hasattr(klass, "__abstractmethods__")):
+            return False
+        if not len(klass.__abstractmethods__):
+            return False
+        return True
+
+    def _is_private_module(module):
+        return "._" in module
+
+    def _is_ignored_module(module):
+        module_parts = module.split(".")
+        return any(part in MODULES_TO_IGNORE for part in module_parts)
+
+    def _is_base_class(name):
+        return name.startswith("_") or name.startswith("Base")
+
+    def _is_estimator(name, klass):
+        # Check if klass is subclass of base estimators, not an base class itself and
+        # not an abstract class
+        return issubclass(klass, BaseObject) and not _is_base_class(name)
+
+    # Ignore deprecation warnings triggered at import time and from walking
+    # packages
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=FutureWarning)
+        warnings.simplefilter("module", category=ImportWarning)
+        warnings.filterwarnings(
+            "ignore", category=UserWarning, message=".*has been moved to.*"
+        )
+        prefix = f"{package_name}."
+        for _, module_name, _ in pkgutil.walk_packages(path=[ROOT], prefix=prefix):
+
+            # Filter modules
+            if _is_ignored_module(module_name) or _is_private_module(module_name):
+                continue
+
+            try:
+                if suppress_import_stdout:
+                    # setup text trap, import, then restore
+                    sys.stdout = io.StringIO()
+                    module = import_module(module_name)
+                    sys.stdout = sys.__stdout__
+                else:
+                    module = import_module(module_name)
+                classes = inspect.getmembers(module, inspect.isclass)
+
+                # Filter classes
+                estimators = [
+                    (name, klass)
+                    for name, klass in classes
+                    if _is_estimator(name, klass)
+                ]
+                all_estimators.extend(estimators)
+            except ModuleNotFoundError as e:
+                # Skip missing soft dependencies
+                if "soft dependency" not in str(e):
+                    raise e
+                warnings.warn(str(e), ImportWarning)
+
+    # Drop duplicates
+    all_estimators = set(all_estimators)
+
+    # Filter based on given estimator types
+    def _is_in_estimator_types(estimator, estimator_types):
+        return any(isclass(x) and isinstance(estimator, x) for x in estimator_types)
+
+    if estimator_types:
+        estimator_types = _check_list_of_class_or_error(
+            estimator_types, "estimator_types"
+        )
+        all_estimators = [
+            (name, estimator)
+            for name, estimator in all_estimators
+            if _is_in_estimator_types(estimator, estimator_types)
+        ]
+
+    # Filter based on given exclude list
+    if exclude_estimators:
+        exclude_estimators = _check_list_of_str_or_error(
+            exclude_estimators, "exclude_estimators"
+        )
+        all_estimators = [
+            (name, estimator)
+            for name, estimator in all_estimators
+            if name not in exclude_estimators
+        ]
+
+    # Drop duplicates, sort for reproducibility
+    # itemgetter is used to ensure the sort does not extend to the 2nd item of
+    # the tuple
+    all_estimators = sorted(all_estimators, key=itemgetter(0))
+
+    if filter_tags:
+        all_estimators = [
+            (n, est) for (n, est) in all_estimators if _check_tag_cond(est, filter_tags)
+        ]
+
+    # remove names if return_names=False
+    if not return_names:
+        all_estimators = [estimator for (name, estimator) in all_estimators]
+        columns = ["estimator"]
+    else:
+        columns = ["name", "estimator"]
+
+    # add new tuple entries to all_estimators for each tag in return_tags:
+    if return_tags:
+        return_tags = _check_list_of_str_or_error(return_tags, "return_tags")
+        # enrich all_estimators by adding the values for all return_tags tags:
+        if all_estimators:
+            if isinstance(all_estimators[0], tuple):
+                all_estimators = [
+                    (name, est) + _get_return_tags(est, return_tags)
+                    for (name, est) in all_estimators
+                ]
+            else:
+                all_estimators = [
+                    tuple([est]) + _get_return_tags(est, return_tags)
+                    for est in all_estimators
+                ]
+        columns = columns + return_tags
+
+    # convert to pandas.DataFrame if as_dataframe=True
+    if as_dataframe:
+        all_estimators = pd.DataFrame(all_estimators, columns=columns)
+
+    return all_estimators
+
+
+def _check_list_of_str_or_error(arg_to_check, arg_name):
+    """Check that certain arguments are str or list of str.
+
+    Parameters
+    ----------
+    arg_to_check: argument we are testing the type of
+    arg_name: str,
+        name of the argument we are testing, will be added to the error if
+        ``arg_to_check`` is not a str or a list of str
+
+    Returns
+    -------
+    arg_to_check: list of str,
+        if arg_to_check was originally a str it converts it into a list of str
+        so that it can be iterated over.
+
+    Raises
+    ------
+    TypeError if arg_to_check is not a str or list of str
+    """
+    # check that return_tags has the right type:
+    if isinstance(arg_to_check, str):
+        arg_to_check = [arg_to_check]
+    if not isinstance(arg_to_check, list) or not all(
+        isinstance(value, str) for value in arg_to_check
+    ):
+        raise TypeError(
+            f"Error in all_estimators!  Argument {arg_name} must be either\
+             a str or list of str"
+        )
+    return arg_to_check
+
+
+def _check_list_of_class_or_error(arg_to_check, arg_name):
+    """Check that certain arguments are class or list of class.
+
+    Parameters
+    ----------
+    arg_to_check: argument we are testing the type of
+    arg_name: str,
+        name of the argument we are testing, will be added to the error if
+        ``arg_to_check`` is not a str or a list of str
+
+    Returns
+    -------
+    arg_to_check: list of class,
+        if arg_to_check was originally a class it converts it into a list of class
+        so that it can be iterated over.
+
+    Raises
+    ------
+    TypeError if arg_to_check is not a class or list of class
+    """
+    # check that return_tags has the right type:
+    if isclass(arg_to_check, str):
+        arg_to_check = [arg_to_check]
+    if not isinstance(arg_to_check, list) or not all(
+        isclass(value) for value in arg_to_check
+    ):
+        raise TypeError(
+            f"Error in all_estimators!  Argument {arg_name} must be either\
+             a class or list of class"
+        )
+    return arg_to_check
+
+
+def _get_return_tags(estimator, return_tags):
+    """Fetch a list of all tags for every_entry of all_estimators.
+
+    Parameters
+    ----------
+    estimator:  BaseEstimator, an sktime estimator
+    return_tags: list of str,
+        names of tags to get values for the estimator
+
+    Returns
+    -------
+    tags: a tuple with all the estimators values for all tags in return tags.
+        a value is None if it is not a valid tag for the estimator provided.
+    """
+    tags = tuple(estimator.get_class_tag(tag) for tag in return_tags)
+    return tags
+
+
+def _check_tag_cond(estimator, filter_tags=None, as_dataframe=True):
+    """Check whether estimator satisfies filter_tags condition.
+
+    Parameters
+    ----------
+    estimator: BaseEstimator, an sktime estimator
+    filter_tags: dict of (str or list of str), default=None
+        subsets the returned estimators as follows:
+            each key/value pair is statement in "and"/conjunction
+                key is tag name to sub-set on
+                value str or list of string are tag values
+                condition is "key must be equal to value, or in set(value)"
+    as_dataframe: bool, default=False
+                if False, return is as described below;
+                if True, return is converted into a pandas.DataFrame for pretty
+                display
+
+    Returns
+    -------
+    cond_sat: bool, whether estimator satisfies condition in filter_tags
+    """
+    if not isinstance(filter_tags, dict):
+        raise TypeError("filter_tags must be a dict")
+
+    cond_sat = True
+
+    for (key, value) in filter_tags.items():
+        if not isinstance(value, list):
+            value = [value]
+        cond_sat = cond_sat and estimator.get_class_tag(key) in set(value)
+
+    return cond_sat
+
+
+def all_tags(
+    estimator_types=None,
+    as_dataframe=False,
+):
+    """Get a list of all tags from sktime.
+
+    Retrieves tags directly from `_tags`, offers filtering functionality.
+
+    Parameters
+    ----------
+    estimator_types: string, list of string, optional (default=None)
+        Which kind of estimators should be returned.
+        - If None, no filter is applied and all estimators are returned.
+        - Possible values are 'classifier', 'regressor', 'transformer' and
+        'forecaster' to get estimators only of these specific types, or a list of
+        these to get the estimators that fit at least one of the types.
+    as_dataframe: bool, optional (default=False)
+                if False, return is as described below;
+                if True, return is converted into a pandas.DataFrame for pretty
+                display
+
+    Returns
+    -------
+    tags: list of tuples (a, b, c, d),
+        in alphabetical order by a
+        a : string - name of the tag as used in the _tags dictionary
+        b : string - name of the scitype this tag applies to
+                    must be in _base_classes.BASE_CLASS_SCITYPE_LIST
+        c : string - expected type of the tag value
+            should be one of:
+                "bool" - valid values are True/False
+                "int" - valid values are all integers
+                "str" - valid values are all strings
+                ("str", list_of_string) - any string in list_of_string is valid
+                ("list", list_of_string) - any individual string and sub-list is valid
+        d : string - plain English description of the tag
+    """
+
+    def is_tag_for_type(tag, estimator_types):
+        tag_types = tag[1]
+        tag_types = _check_list_of_str_or_error(tag_types, "tag_types")
+
+        if isinstance(estimator_types, str):
+            estimator_types = [estimator_types]
+
+        tag_types = set(tag_types)
+        estimator_types = set(estimator_types)
+        is_valid_tag_for_type = len(tag_types.intersection(estimator_types)) > 0
+
+        return is_valid_tag_for_type
+
+    all_tags = ESTIMATOR_TAG_REGISTER
+
+    if estimator_types:
+        # checking, but not using the return since that is classes, not strings
+        _check_estimator_types(estimator_types)
+        all_tags = [tag for tag in all_tags if is_tag_for_type(tag, estimator_types)]
+
+    all_tags = sorted(all_tags, key=itemgetter(0))
+
+    # convert to pd.DataFrame if as_dataframe=True
+    if as_dataframe:
+        columns = ["name", "scitype", "type", "description"]
+        all_tags = pd.DataFrame(all_tags, columns=columns)
+
+    return all_tags
+
+
+def _check_estimator_types(estimator_types):
+    """Return list of classes corresponding to type strings."""
+    estimator_types = deepcopy(estimator_types)
+
+    if not isinstance(estimator_types, list):
+        estimator_types = [estimator_types]  # make iterable
+
+    def _get_err_msg(estimator_type):
+        return (
+            f"Parameter `estimator_type` must be None, a string or a list of "
+            f"strings. Valid string values are: "
+            f"{tuple(BASE_CLASS_LOOKUP.keys())}, but found: "
+            f"{repr(estimator_type)}"
+        )
+
+    for i, estimator_type in enumerate(estimator_types):
+        if not isinstance(estimator_type, (type, str)):
+            raise ValueError(
+                "Please specify `estimator_types` as a list of str or " "types."
+            )
+        if isinstance(estimator_type, str):
+            if estimator_type not in BASE_CLASS_LOOKUP.keys():
+                raise ValueError(_get_err_msg(estimator_type))
+            estimator_type = BASE_CLASS_LOOKUP[estimator_type]
+            estimator_types[i] = estimator_type
+        elif isinstance(estimator_type, type):
+            pass
+        else:
+            raise ValueError(_get_err_msg(estimator_type))
+    return estimator_types

--- a/baseobject/_lookup.py
+++ b/baseobject/_lookup.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from types import FunctionType, ModuleType
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
-from base_object import BaseObject
+from baseobject import BaseObject
 
 # Conditionally import TypedDict based on Python version
 if sys.version_info >= (3, 9):

--- a/baseobject/_lookup.py
+++ b/baseobject/_lookup.py
@@ -9,6 +9,9 @@ all_estimators(estimator_types, filter_tags)
     lookup and filtering of objects (BaseObject descendants)
 """
 
+__author__ = ["fkiraly", "mloning", "katiebuc", "rnkuhns"]
+
+
 import pkgutil
 from copy import deepcopy
 from importlib import import_module

--- a/baseobject/_lookup.py
+++ b/baseobject/_lookup.py
@@ -9,7 +9,7 @@ all_estimators(estimator_types, filter_tags)
     lookup and filtering of objects (BaseObject descendants)
 """
 
-__author__ = ["fkiraly", "mloning", "katiebuc", "rnkuhns"]
+__author__ = ["fkiraly", "mloning", "katiebuc", "miraep8", "xloem", "rnkuhns"]
 # based on the sktime estimator retrieval utility of the same name
 # which, in turn, is based on the sklearn estimator retrieval utility of the same name
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 ]
 requires-python = ">=3.7,<3.11"
 dependencies = [
-    "scikit-learn>=0.24.0,<1.2.0",
+    "scikit-learn>=0.24.0,<1.2.0", "typing_extensions"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR moves a slightly refactored lookup utility `all_estimators` over from `sktime`.

Changes are made to decouple the utility from:
* the base class registry. Instead, this is passed as an alias dictionary `class_dict`. Estimator types are now passed as classes directly, and can be passed as strings (like in `sktime`) if the alias dictionary is provided.
* `pandas`. This is now a soft dependency that is needed only when `as_dataframe` is set to `True`, allowing the `baseobject` package to not depend on `pandas`.