### PR TITLE
[ENH] up `flake8` max line length to 88

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,6 @@ universal = false
 
 [sdist]
 formats = gztar
+
+[flake8]
+max-line-length = 88


### PR DESCRIPTION
This increases max line length for `flake8` to 88, in line with `sktime`.