### PR TITLE
[ENH] remove `TagAliaserMixin` from `BaseEstimator`

### DIFF
--- a/baseobject/_base.py
+++ b/baseobject/_base.py
@@ -511,19 +511,12 @@ class TagAliaserMixin:
 
     # dictionary of aliases
     # key = old tag; value = new tag, aliased by old tag
-    alias_dict = {
-        "fit-in-transform": "fit_is_empty",
-        "fit-in-predict": "fit_is_empty",
-        "capability:early_prediction": "",
-    }
+    # override this in a child class
+    alias_dict = {"old_tag": "new_tag", "tag_to_remove": ""}
 
     # dictionary of removal version
     # key = old tag; value = version in which tag will be removed, as string
-    deprecate_dict = {
-        "fit-in-transform": "0.12.0",
-        "fit-in-predict": "0.12.0",
-        "capability:early_prediction": "0.13.0",
-    }
+    deprecate_dict = {"old_tag": "0.12.0", "tag_to_remove": "99.99.99"}
 
     def __init__(self):
         super(TagAliaserMixin, self).__init__()
@@ -682,7 +675,7 @@ class TagAliaserMixin:
                 warnings.warn(msg, category=DeprecationWarning)
 
 
-class BaseEstimator(TagAliaserMixin, BaseObject):
+class BaseEstimator(BaseObject):
     """Base class for defining estimators in sktime.
 
     Extends sktime's BaseObject to include basic functionality for fittable estimators.


### PR DESCRIPTION
Removes the `TagAliaserMixin´ from the `BaseEstimator` as there are no tags to alias.