### PR TITLE
[ENH] robustify `all_objects` exclusion behaviour

### DIFF
--- a/baseobject/_lookup.py
+++ b/baseobject/_lookup.py
@@ -46,7 +46,7 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import TypedDict
 
-__all__: List[str] = ["all_objects", "gather_package_metadata"]
+__all__: List[str] = ["all_objects", "get_package_metadata"]
 __author__: List[str] = [
     "fkiraly",
     "mloning",
@@ -462,7 +462,7 @@ def _get_module_info(
     return module_info
 
 
-def gather_package_metadata(
+def get_package_metadata(
     package_name: str,
     path: Optional[str] = None,
     recursive: bool = True,
@@ -591,7 +591,7 @@ def gather_package_metadata(
                 name_ending: str = name.split(".")[1] if "." in name else name
                 updated_path: str = "\\".join([path, name_ending])
                 module_info.update(
-                    gather_package_metadata(
+                    get_package_metadata(
                         package_name=name,
                         path=updated_path,
                         recursive=recursive,

--- a/baseobject/_lookup.py
+++ b/baseobject/_lookup.py
@@ -744,9 +744,7 @@ def all_objects(
             "ignore", category=UserWarning, message=".*has been moved to.*"
         )
         prefix = f"{package_name}."
-        for module_name in _walk(
-            root=root, exclude=modules_to_ignore, prefix=prefix
-        ):
+        for module_name in _walk(root=root, exclude=modules_to_ignore, prefix=prefix):
             # Filter modules
             if _is_private_module(module_name):
                 continue


### PR DESCRIPTION
This robustifies the `all_objects` exclusion behaviour, by avoiding to import excluded modules or their sub-modules on the `ignore_modules` list.

This is in particular relevant if such an import would lead to circular imports.

The change in logic is to avoid importing the ignored modules altogether, instead of importing and then discarding - the former avoids circular imports, the latter runs into the problem of circular imports, potentially.

Also see https://github.com/alan-turing-institute/sktime/pull/3198 in `sktime`.