### PR TITLE
[ENH] robustify `BaseObject.set_tags` against forgotten `__init__`

### DIFF
--- a/baseobject/_base.py
+++ b/baseobject/_base.py
@@ -344,7 +344,11 @@ class BaseObject(_BaseEstimator):
         Changes object state by settting tag values in tag_dict as dynamic tags
         in self.
         """
-        self._tags_dynamic.update(deepcopy(tag_dict))
+        tag_update = deepcopy(tag_dict)
+        if hasattr(self, "_tags_dynamic"):
+            self._tags_dynamic.update(tag_update)
+        else:
+            self._tags_dynamic = tag_update
 
         return self
 


### PR DESCRIPTION
This PR robustifies `BaseObject.set_tags` against forgotten `__init__`, e.g., if a child object forgets to `super.__init__` (or intentionally does not call `super.__init__`).

Mirrors `sktime` https://github.com/alan-turing-institute/sktime/pull/3226