### PR TITLE
[ENH] fix unix wheel test in release workflow

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -54,7 +54,8 @@ jobs:
         run: python -m pip install "${{ env.WHEELNAME }}[all_extras,dev]"
 
       - name: Run tests
-        run: make test
+        run: |
+          python -m pytest
 
   test_windows_wheels:
     needs: build_wheels


### PR DESCRIPTION
The release CI workflow for unix was breaking as it was running `make test`, but no `make` file was present. This is replaced by a direct `pytest` call.