### PR TITLE
Fix CI error from test coverage reference to old package name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ convention = "numpy"
 show_missing = true
 
 [tool.coverage.run]
-source = ["baseobject"]
+source = ["skbase"]
 omit = ["*/setup.py", "tests/*"]
 
 [tool.doc8]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ show_missing = true
 
 [tool.coverage.run]
 source = ["skbase"]
-omit = ["*/setup.py", "tests/*"]
+omit = ["*/setup.py", "tests/*", "docs/*", "skbase/tests/*"]
 
 [tool.doc8]
 max-line-length = 88


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->



#### What does this implement/fix? Explain your changes.
This fixes an error that is causing test failures in other PRs due to a reference to the baseobject package in the configuration for test coverage in the package's `pyproject.toml`. The reference to `baseobject` was updated to `skbase`. 

Also updated the excluded directories to exclude the docs and tests from coverage.

#### Does your contribution introduce a new dependency? If yes, which one?

None.

#### What should a reviewer concentrate their feedback on?

Tests run successfully and decision on excluding tests and docs from coverage.
