### PR TITLE
Update known_first_party option in isort config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ addopts = [
 profile = "black"
 src_paths = ["isort", "test"]
 multi_line_output = 3
-known_first_party = ["baseobject"]
+known_first_party = ["skbase"]
 
 [tool.black]
 line-length = 88

--- a/skbase/_base.py
+++ b/skbase/_base.py
@@ -61,9 +61,10 @@ import warnings
 from collections import defaultdict
 from copy import deepcopy
 
-from skbase._exceptions import NotFittedError
 from sklearn import clone
 from sklearn.base import BaseEstimator as _BaseEstimator
+
+from skbase._exceptions import NotFittedError
 
 
 class BaseObject(_BaseEstimator):

--- a/skbase/testing/test_all_objects.py
+++ b/skbase/testing/test_all_objects.py
@@ -15,6 +15,10 @@ from inspect import getfullargspec, isclass, signature
 import joblib
 import numpy as np
 import pytest
+from sklearn.utils.estimator_checks import (
+    check_get_params_invariance as _check_get_params_invariance,
+)
+
 from skbase import BaseObject
 from skbase._lookup import all_objects
 from skbase.testing.utils._conditional_fixtures import (
@@ -22,9 +26,6 @@ from skbase.testing.utils._conditional_fixtures import (
 )
 from skbase.testing.utils.deep_equals import deep_equals
 from skbase.testing.utils.inspect import _get_args
-from sklearn.utils.estimator_checks import (
-    check_get_params_invariance as _check_get_params_invariance,
-)
 
 
 class BaseFixtureGenerator:

--- a/skbase/testing/utils/deep_equals.py
+++ b/skbase/testing/utils/deep_equals.py
@@ -13,6 +13,7 @@ __all__ = ["deep_equals"]
 
 
 import numpy as np
+
 from skbase.testing.utils._dependencies import _check_soft_dependencies
 
 

--- a/skbase/testing/utils/tests/test_deep_equals.py
+++ b/skbase/testing/utils/tests/test_deep_equals.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 
 import numpy as np
 import pytest
+
 from skbase.testing.utils._dependencies import _check_soft_dependencies
 from skbase.testing.utils.deep_equals import deep_equals
 

--- a/skbase/tests/test_base.py
+++ b/skbase/tests/test_base.py
@@ -29,6 +29,7 @@ __all__ = [
 from copy import deepcopy
 
 import pytest
+
 from skbase import BaseObject
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #55.


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
Updates known_first_party option in `pyproject.toml` isort config to be `skbase` not `baseobject`.

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
This may trigger pre-commit.ci to fix the import sorting. Make sure that looks right if it happens.
